### PR TITLE
[FIX] Varying sidebar top items

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,7 +7,15 @@ async function main() {
 	const sidebarItem = await waitForSidebar();
 	const div = document.createElement("div");
 
-	ReactDOM.render(<SearchInput />, div);
+	/** To get scrolling in the filtered list working*/
+	const onFilter = (searchCleared: boolean) => {
+		if (searchCleared)
+			div.removeAttribute("style");
+		else
+			div.setAttribute("style", "height: 100vh; max-height: 100%;");
+	};
+
+	ReactDOM.render(<SearchInput onFilter={onFilter} />, div);
 
 	sidebarItem.parentNode!.insertBefore(div, sidebarItem.nextSibling);
 

--- a/src/components/PlaylistFilter.tsx
+++ b/src/components/PlaylistFilter.tsx
@@ -1,13 +1,17 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { SpotifyClient } from "../clients/SpotifyClient";
 import { getConfig } from "../config/Config";
 import { USE_KEYBOARD_SHORTCUTS } from "../constants/constants";
 import { Playlist } from "../models/Playlist";
 import { flattenLibrary } from "../utils/utils";
 import { PlaylistItem } from "./PlaylistItem";
-import { clearButtonStyling, JUa6JJNj7R_Y3i4P8YUXStyling, mainRootlistContentStyling, osContentStyling, osPaddingStyling, osViewportStyling, searchInputStyling, searchStyling } from "./styling/PlaylistFilterStyling";
+import { clearButtonStyling, searchInputStyling, searchStyling, ulStyling } from "./styling/PlaylistFilterStyling";
 
-export const SearchInput = (() => {
+interface Props {
+	onFilter: (searchCleared: boolean) => void;
+}
+
+export const SearchInput = (({ onFilter }: Props) => {
 	const [playlists, setPlaylists] = useState<Playlist[]>([]);
 	const [playlistContainer, setPlaylistContainer] = useState(document.querySelector("#spicetify-playlist-list"));
 	const [searchTerm, setSearchTerm] = useState("");
@@ -45,21 +49,26 @@ export const SearchInput = (() => {
 
 		await setSearchTerm(value === " " ? "" : value);
 
-		if (value === "" || value === " ")
+		if (value === "" || value === " ") {
+			onFilter(true);
 			playlistContainer?.removeAttribute("style");
-		else
+		}
+		else {
+			onFilter(false);
 			playlistContainer?.setAttribute("style", "display: none;");
+		}
+
 	}
 
 	const clearFilter = async () => {
 		await filterPlaylists(" ");
 	};
 
-	const searchResults = playlists.filter(playlist => {
+	const searchResults = useMemo(() => playlists.filter(playlist => {
 		return playlist.name.toLowerCase().includes(searchTerm.toLowerCase());
-	});
+	}), [searchTerm]);
 
-	const sortedSearchResults = searchResults.sort((a, b) => {
+	const sortedSearchResults = useMemo(() => searchResults.sort((a, b) => {
 		const aMatch = a.name.toLowerCase().indexOf(searchTerm.toLowerCase());
 		const bMatch = b.name.toLowerCase().indexOf(searchTerm.toLowerCase());
 
@@ -71,88 +80,62 @@ export const SearchInput = (() => {
 			return -1;
 		else
 			return 0;
-	});
+	}), [searchResults]);
 
 	return (
-		<div>
-			<div>
-				<div style={searchStyling}>
-					<input
-						style={searchInputStyling}
-						// @ts-ignore
-						ref={searchInput}
-						placeholder="Filter"
-						value={searchTerm}
-						onChange={(e) => filterPlaylists(e.target.value)}
-						onKeyDown={(e) => {
-							if (e.key === "Escape") {
-								clearFilter();
-								searchInput.current?.blur();
-							}
-						}}
-					/>
-					{
-						searchTerm !== "" &&
-						<div
-							style={clearButtonStyling}
-							title="Clear filter"
-							onClick={clearFilter}
-						>
-							<svg
-								style={{
-									fill: "var(--text-subdued)"
-								}}
-								dangerouslySetInnerHTML={{
-									// @ts-ignore
-									__html: Spicetify.SVGIcons["x"]
-								}} />
-						</div>
-					}
-				</div>
-
-
-				<div className="main-rootlist-rootlistDividerContainer">
-					<hr className="main-rootlist-rootlistDivider" />
-					<div className="main-rootlist-rootlistDividerGradient" />
-				</div>
-
+		<>
+			<div style={searchStyling}>
+				<input
+					style={searchInputStyling}
+					// @ts-ignore
+					ref={searchInput}
+					placeholder="Filter"
+					value={searchTerm}
+					onChange={(e) => filterPlaylists(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Escape") {
+							clearFilter();
+							searchInput.current?.blur();
+						}
+					}}
+				/>
 				{
-					searchTerm &&
+					searchTerm !== "" &&
 					<div
-					// className="main-rootlist-rootlistContent"
-					// style={mainRootlistContentStyling}
+						style={clearButtonStyling}
+						title="Clear filter"
+						onClick={clearFilter}
 					>
-						<div
-						// className="os-padding"
-						// style={osPaddingStyling}
-						>
-							<div
-								// className="os-viewport os-viewport-native-scrollbars-invisible"
-								style={osViewportStyling}
-							>
-								<div className="os-content"
-									style={osContentStyling}>
-									<ul>
-										<div
-											className="JUa6JJNj7R_Y3i4P8YUX"
-											style={JUa6JJNj7R_Y3i4P8YUXStyling}
-										>
-											{sortedSearchResults
-												.map((playlist: any) => (
-													<PlaylistItem
-														searchTerm={searchTerm}
-														playlist={playlist}
-														key={playlist.uri}
-													/>
-												))}
-										</div>
-									</ul>
-								</div>
-							</div>
-						</div>
+						<svg
+							style={{
+								fill: "var(--text-subdued)"
+							}}
+							dangerouslySetInnerHTML={{
+								// @ts-ignore
+								__html: Spicetify.SVGIcons["x"]
+							}} />
 					</div>
 				}
 			</div>
-		</div>
+
+			<div className="main-rootlist-rootlistDividerContainer">
+				<hr className="main-rootlist-rootlistDivider" />
+				<div className="main-rootlist-rootlistDividerGradient" />
+			</div>
+
+			{
+				searchTerm &&
+				<ul style={ulStyling}>
+					{sortedSearchResults
+						.map((playlist: any, i: number) => (
+							<PlaylistItem
+								searchTerm={searchTerm}
+								playlist={playlist}
+								key={playlist.uri + i}
+							/>
+						))}
+				</ul>
+			}
+		</>
 	);
 });

--- a/src/components/PlaylistFilter.tsx
+++ b/src/components/PlaylistFilter.tsx
@@ -74,81 +74,85 @@ export const SearchInput = (() => {
 	});
 
 	return (
-		<>
-			<div style={searchStyling}>
-				<input
-					style={searchInputStyling}
-					// @ts-ignore
-					ref={searchInput}
-					placeholder="Filter"
-					value={searchTerm}
-					onChange={(e) => filterPlaylists(e.target.value)}
-					onKeyDown={(e) => {
-						if (e.key === "Escape") {
-							clearFilter();
-							searchInput.current?.blur();
-						}
-					}}
-				/>
+		<div>
+			<div>
+				<div style={searchStyling}>
+					<input
+						style={searchInputStyling}
+						// @ts-ignore
+						ref={searchInput}
+						placeholder="Filter"
+						value={searchTerm}
+						onChange={(e) => filterPlaylists(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Escape") {
+								clearFilter();
+								searchInput.current?.blur();
+							}
+						}}
+					/>
+					{
+						searchTerm !== "" &&
+						<div
+							style={clearButtonStyling}
+							title="Clear filter"
+							onClick={clearFilter}
+						>
+							<svg
+								style={{
+									fill: "var(--text-subdued)"
+								}}
+								dangerouslySetInnerHTML={{
+									// @ts-ignore
+									__html: Spicetify.SVGIcons["x"]
+								}} />
+						</div>
+					}
+				</div>
+
+
+				<div className="main-rootlist-rootlistDividerContainer">
+					<hr className="main-rootlist-rootlistDivider" />
+					<div className="main-rootlist-rootlistDividerGradient" />
+				</div>
+
 				{
-					searchTerm !== "" &&
+					searchTerm &&
 					<div
-						style={clearButtonStyling}
-						title="Clear filter"
-						onClick={clearFilter}
-					>
-						<svg
-							style={{
-								fill: "var(--text-subdued)"
-							}}
-							dangerouslySetInnerHTML={{
-								// @ts-ignore
-								__html: Spicetify.SVGIcons["x"]
-							}} />
-					</div>
-				}
-			</div>
-
-			<div className="main-rootlist-rootlistDividerContainer">
-				<hr className="main-rootlist-rootlistDivider" />
-				<div className="main-rootlist-rootlistDividerGradient" />
-			</div>
-
-			{
-				searchTerm &&
-				<div
-					className="main-rootlist-rootlistContent"
-					style={mainRootlistContentStyling}>
-					<div
-						className="os-padding"
-						style={osPaddingStyling}
+					// className="main-rootlist-rootlistContent"
+					// style={mainRootlistContentStyling}
 					>
 						<div
-							className="os-viewport os-viewport-native-scrollbars-invisible"
-							style={osViewportStyling}
+						// className="os-padding"
+						// style={osPaddingStyling}
 						>
-							<div className="os-content"
-								style={osContentStyling}>
-								<ul>
-									<div
-										className="JUa6JJNj7R_Y3i4P8YUX"
-										style={JUa6JJNj7R_Y3i4P8YUXStyling}
-									>
-										{sortedSearchResults
-											.map((playlist: any) => (
-												<PlaylistItem
-													searchTerm={searchTerm}
-													playlist={playlist}
-													key={playlist.uri}
-												/>
-											))}
-									</div>
-								</ul>
+							<div
+								// className="os-viewport os-viewport-native-scrollbars-invisible"
+								style={osViewportStyling}
+							>
+								<div className="os-content"
+									style={osContentStyling}>
+									<ul>
+										<div
+											className="JUa6JJNj7R_Y3i4P8YUX"
+											style={JUa6JJNj7R_Y3i4P8YUXStyling}
+										>
+											{sortedSearchResults
+												.map((playlist: any) => (
+													<PlaylistItem
+														searchTerm={searchTerm}
+														playlist={playlist}
+														key={playlist.uri}
+													/>
+												))}
+										</div>
+									</ul>
+								</div>
 							</div>
 						</div>
 					</div>
-				</div>
-			}
-		</>
+				}
+			</div>
+		</div>
 	);
 });

--- a/src/components/PlaylistItem.tsx
+++ b/src/components/PlaylistItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Playlist } from "../models/Playlist";
-import { listItemStyling, mainRootlistItemRootlistItemStyling, mainRootlistTextWrapperStyling } from "./styling/PlaylistItemStyling";
+import { listItemStyling, mainRootlistItemRootlistItemStyling } from "./styling/PlaylistItemStyling";
 
 interface Props {
 	playlist: Playlist;
@@ -16,7 +16,7 @@ export const PlaylistItem = ({ playlist, searchTerm }: Props) => {
 		else {
 			let highlightedName = name.replace(new RegExp(searchTerm, "gi"), (match) => {
 				// return `<span style="background-color: #161616fa; color: #fff;">${match}</span>`;
-				return `<span style="background-color: #f7f7f737; color: #fff;">${match}</span>`;
+				return `<span style="background-color: rgb(255 255 255 / 8%); color: #fff;">${match}</span>`;
 			});
 
 			highlightedName = highlightedName.replace(/span> /g, "span>&nbsp;");
@@ -62,7 +62,6 @@ export const PlaylistItem = ({ playlist, searchTerm }: Props) => {
 					<span
 						className="main-rootlist-textWrapper main-type-viola"
 						dir="auto"
-						style={mainRootlistTextWrapperStyling}
 					>
 						<span dangerouslySetInnerHTML={{ __html: getNameWithHighlightedSearchTerm() }} />
 					</span>

--- a/src/components/PlaylistItem.tsx
+++ b/src/components/PlaylistItem.tsx
@@ -15,7 +15,8 @@ export const PlaylistItem = ({ playlist, searchTerm }: Props) => {
 			return name;
 		else {
 			let highlightedName = name.replace(new RegExp(searchTerm, "gi"), (match) => {
-				return `<span style="background-color: #161616fa; color: #fff;">${match}</span>`;
+				// return `<span style="background-color: #161616fa; color: #fff;">${match}</span>`;
+				return `<span style="background-color: #f7f7f737; color: #fff;">${match}</span>`;
 			});
 
 			highlightedName = highlightedName.replace(/span> /g, "span>&nbsp;");
@@ -42,7 +43,7 @@ export const PlaylistItem = ({ playlist, searchTerm }: Props) => {
 	};
 
 	return (
-		<li className="GlueDropTarget GlueDropTarget--playlists GlueDropTarget--folders GlueDropTarget--tracks GlueDropTarget--albums GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders"
+		<li className="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders"
 			style={listItemStyling}
 		>
 			<div

--- a/src/components/PlaylistItem.tsx
+++ b/src/components/PlaylistItem.tsx
@@ -43,7 +43,8 @@ export const PlaylistItem = ({ playlist, searchTerm }: Props) => {
 	};
 
 	return (
-		<li className="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders"
+		<li
+			className="GlueDropTarget GlueDropTarget--albums GlueDropTarget--tracks GlueDropTarget--local-tracks GlueDropTarget--episodes GlueDropTarget--playlists GlueDropTarget--folders"
 			style={listItemStyling}
 		>
 			<div

--- a/src/components/PlaylistItem.tsx
+++ b/src/components/PlaylistItem.tsx
@@ -15,7 +15,6 @@ export const PlaylistItem = ({ playlist, searchTerm }: Props) => {
 			return name;
 		else {
 			let highlightedName = name.replace(new RegExp(searchTerm, "gi"), (match) => {
-				// return `<span style="background-color: #161616fa; color: #fff;">${match}</span>`;
 				return `<span style="background-color: rgb(255 255 255 / 8%); color: #fff;">${match}</span>`;
 			});
 

--- a/src/components/styling/PlaylistFilterStyling.tsx
+++ b/src/components/styling/PlaylistFilterStyling.tsx
@@ -1,25 +1,17 @@
 export const searchStyling: React.CSSProperties = {
 	display: "flex",
-	// top: 0,
 	width: "100%",
 	paddingLeft: 16,
 	paddingRight: 16,
-	zIndex: 5000,
-	marginTop: -1,
 	paddingTop: 7
 }
 
 export const clearButtonStyling: React.CSSProperties = {
 	width: 39,
 	height: 39,
-	display: "flex",
-	justifyContent: "center",
-	justifyItems: "center",
-	alignContent: "center",
 	padding: 12,
 	backgroundColor: "transparent",
-	fontWeight: "bold",
-	zIndex: 5000
+	fontWeight: "bold"
 };
 
 export const searchInputStyling: React.CSSProperties = {
@@ -29,17 +21,7 @@ export const searchInputStyling: React.CSSProperties = {
 	padding: 10,
 	height: 39,
 	color: "var(--text-subdued)",
-	fontSize: 14,
-	zIndex: 5000
-};
-
-export const osContentStyling: React.CSSProperties = {
-	// padding: "8px 0px",
-	// height: "100%",
-	// width: "100%;",
-	// marginTop: 56,
-	// overflow: "scroll",
-	// paddingBottom: 150 // TODO: fix this
+	fontSize: "inherit"
 };
 
 export const mainRootlistContentStyling: React.CSSProperties = {
@@ -47,16 +29,10 @@ export const mainRootlistContentStyling: React.CSSProperties = {
 	height: "100%",
 }
 
-export const osPaddingStyling: React.CSSProperties = {
-	zIndex: 4999
-};
-
-export const osViewportStyling: React.CSSProperties = {
-	zIndex: 4999
-};
-
-export const JUa6JJNj7R_Y3i4P8YUXStyling: React.CSSProperties = {
+export const ulStyling: React.CSSProperties = {
 	contain: "none",
-	marginTop: 8,
-	overflow: "scroll"
+	paddingTop: 8,
+	overflow: "scroll",
+	height: "inherit",
+	maxHeight: "calc(100% - 100px)"
 };

--- a/src/components/styling/PlaylistFilterStyling.tsx
+++ b/src/components/styling/PlaylistFilterStyling.tsx
@@ -1,3 +1,14 @@
+export const searchStyling: React.CSSProperties = {
+	display: "flex",
+	// top: 0,
+	width: "100%",
+	paddingLeft: 16,
+	paddingRight: 16,
+	zIndex: 5000,
+	marginTop: -1,
+	paddingTop: 7
+}
+
 export const clearButtonStyling: React.CSSProperties = {
 	width: 39,
 	height: 39,
@@ -6,24 +17,14 @@ export const clearButtonStyling: React.CSSProperties = {
 	justifyItems: "center",
 	alignContent: "center",
 	padding: 12,
-	backgroundColor: "#000",
+	backgroundColor: "transparent",
 	fontWeight: "bold",
 	zIndex: 5000
 };
 
-export const searchStyling: React.CSSProperties = {
-	display: "flex",
-	top: 0,
-	width: "100%",
-	paddingLeft: 16,
-	paddingRight: 16,
-	zIndex: 5000,
-	marginTop: -1
-}
-
 export const searchInputStyling: React.CSSProperties = {
 	width: "100%",
-	backgroundColor: "#000",
+	backgroundColor: "transparent",
 	border: "none",
 	padding: 10,
 	height: 39,
@@ -33,12 +34,12 @@ export const searchInputStyling: React.CSSProperties = {
 };
 
 export const osContentStyling: React.CSSProperties = {
-	padding: "8px 0px",
-	height: "100%",
-	width: "100%;",
-	marginTop: 56,
-	overflow: "scroll",
-	paddingBottom: 150 // TODO: fix this
+	// padding: "8px 0px",
+	// height: "100%",
+	// width: "100%;",
+	// marginTop: 56,
+	// overflow: "scroll",
+	// paddingBottom: 150 // TODO: fix this
 };
 
 export const mainRootlistContentStyling: React.CSSProperties = {
@@ -46,8 +47,16 @@ export const mainRootlistContentStyling: React.CSSProperties = {
 	height: "100%",
 }
 
-export const osPaddingStyling: React.CSSProperties = { zIndex: 4999 };
+export const osPaddingStyling: React.CSSProperties = {
+	zIndex: 4999
+};
 
-export const osViewportStyling: React.CSSProperties = { zIndex: 4999 };
+export const osViewportStyling: React.CSSProperties = {
+	zIndex: 4999
+};
 
-export const JUa6JJNj7R_Y3i4P8YUXStyling: React.CSSProperties = { contain: "none" };
+export const JUa6JJNj7R_Y3i4P8YUXStyling: React.CSSProperties = {
+	contain: "none",
+	marginTop: 8,
+	overflow: "scroll"
+};

--- a/src/components/styling/PlaylistItemStyling.tsx
+++ b/src/components/styling/PlaylistItemStyling.tsx
@@ -1,8 +1,3 @@
 export const listItemStyling = { zIndex: 5001 };
 
 export const mainRootlistItemRootlistItemStyling = { marginLeft: 24 };
-
-export const mainRootlistTextWrapperStyling = {
-	display: "flex",
-	alignItems: "center"
-};


### PR DESCRIPTION
As pointed out https://github.com/Florry/spicetify-playlist-filter/issues/1, depending on how many top items in the playlist panel there were, the filter results would end up in the same place (and not in relation to the filter box / the playlist list). Fixes that, as well as simplifying the html structure a bit and makes colors be transparent rather than black/grey to better fit with custom themes. 