### PR TITLE
fix: don't set empty keyboard shortcut

### DIFF
--- a/src/components/PlaylistFilter.tsx
+++ b/src/components/PlaylistFilter.tsx
@@ -27,16 +27,15 @@ export const SearchInput = (({ onFilter }: Props) => {
 
     useEffect(() => {
         getPlaylists();
-
-        Spicetify.Keyboard.registerImportantShortcut("f", async () => {
-            if (getConfig(USE_KEYBOARD_SHORTCUTS)) {
+        if (getConfig(USE_KEYBOARD_SHORTCUTS)) {
+            Spicetify.Keyboard.registerImportantShortcut("f", async () => {
                 /* Without setImmediate here, the value of searchInput is set to f for some reason */
                 setImmediate(() => {
                     if (searchInput.current)
                         searchInput.current.focus();
                 });
-            }
-        });
+            });
+        }
 
         // Refreshes playlists every 30 min
         // TODO: find a better solution


### PR DESCRIPTION
If the user chooses not to use keyboard shortcuts, then an empty shortcut should not be set on <kbd>f</kbd> button press.